### PR TITLE
Add configuration option to enable historical bookings

### DIFF
--- a/action.php
+++ b/action.php
@@ -168,9 +168,19 @@ class action_plugin_booking extends DokuWiki_Action_Plugin
     {
         $form = new dokuwiki\Form\Form();
         $form->addFieldsetOpen($this->getLang('headline'));
+
+        if ($this->getConf('add historical bookings')) {
+            // allow historical bookings for the current year or up to two
+            // months ago, whichever is earlier
+            $year = date('Y');
+            $min_date = min(strtotime("1-1-{$year}"), strtotime("-2 months"));
+        } else {
+            $min_date = time();
+        }
         $form->addTextInput('date')
-            ->attrs(['type' => 'date', 'min' => date('Y-m-d'), 'required' => 'required'])
-            ->addClass('edit');
+             ->attrs(['type' => 'date', 'min' => date('Y-m-d', $min_date), 'required' => 'required'])
+             ->addClass('edit');
+
         $form->addTextInput('time')
             ->attrs(['type' => 'time', 'required' => 'required'])
             ->val(date('H', time() + 60 * 60) . ':00')

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+
+$conf['add historical bookings'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,3 @@
+<?php
+
+$meta['add historical bookings'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['add historical bookings'] = 'Enable adding of historical bookings (up to the beginning of the year or two months ago, whichever is earlier)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,3 @@
 <?php
 
-$lang['add historical bookings'] = 'Enable adding of historical bookings (up to the beginning of the year or two months ago, whichever is earlier)';
+$lang['add historical bookings'] = 'Enable adding of historical bookings (to beginning of year or two months ago, whichever is earlier)';


### PR DESCRIPTION
This creates a configuration option that when enabled, allows users to enter bookings for earlier dates. While these will not be visible on the main booking screen, they are listed in the exported CSV file, and so are useful for record keeping.