### PR TITLE
Column labels

### DIFF
--- a/action.php
+++ b/action.php
@@ -168,9 +168,19 @@ class action_plugin_booking extends DokuWiki_Action_Plugin
     {
         $form = new dokuwiki\Form\Form();
         $form->addFieldsetOpen($this->getLang('headline'));
+
+        if ($this->getConf('add historical bookings')) {
+            // allow historical bookings for the current year or up to two
+            // months ago, whichever is earlier
+            $year = date('Y');
+            $min_date = min(strtotime("1-1-{$year}"), strtotime("-2 months"));
+        } else {
+            $min_date = time();
+        }
         $form->addTextInput('date')
-            ->attrs(['type' => 'date', 'min' => date('Y-m-d'), 'required' => 'required'])
-            ->addClass('edit');
+             ->attrs(['type' => 'date', 'min' => date('Y-m-d', $min_date), 'required' => 'required'])
+             ->addClass('edit');
+
         $form->addTextInput('time')
             ->attrs(['type' => 'time', 'required' => 'required'])
             ->val(date('H', time() + 60 * 60) . ':00')

--- a/action.php
+++ b/action.php
@@ -21,6 +21,13 @@ class action_plugin_booking extends DokuWiki_Action_Plugin
     public function __construct()
     {
         $this->helper = plugin_load('helper', 'booking');
+
+        // Get language-specific labels for each column
+        $labels = array();
+        foreach($this->helper->getColumns() as $column) {
+            $labels[] = $this->getLang($column);   
+        }
+        $this->helper->setLabels($labels);
     }
 
 
@@ -202,27 +209,14 @@ class action_plugin_booking extends DokuWiki_Action_Plugin
     protected function listBookings($id)
     {
         $bookings = $this->helper->getBookings($id, time());
-        echo '<table>';
+
+        echo $this->helper->tableHeader($this->getConf('column labels'));
+
         foreach ($bookings as $booking) {
-            echo '<tr>';
-
-            echo '<td>';
-            echo dformat($booking['start']) . ' - ' . dformat($booking['end']);
-            echo '</td>';
-
-            echo '<td>';
-            echo userlink($booking['user']);
-            echo '</td>';
-
-            echo '<td>';
-            if ($booking['user'] == $_SERVER['REMOTE_USER'] || $this->issuperuser) {
-                echo '<a href="#' . $booking['start'] . '" class="cancel">' . $this->getLang('cancel') . '</a>';
-            } else {
-                echo '&nbsp;';
-            }
-            echo '</td>';
-
-            echo '</tr>';
+            $use_cancel_button = ($booking['user'] == $_SERVER['REMOTE_USER']) ||
+                               $this->issuperuser;
+            echo $this->helper->tableRow($booking, $use_cancel_button,
+                                         $this->getLang('cancel'));
         }
         echo '</table>';
 

--- a/action.php
+++ b/action.php
@@ -25,7 +25,7 @@ class action_plugin_booking extends DokuWiki_Action_Plugin
         // Get language-specific labels for each column
         $labels = array();
         foreach($this->helper->getColumns() as $column) {
-            $labels[] = $this->getLang($column);   
+            $labels[] = $this->getLang($column);
         }
         $this->helper->setLabels($labels);
     }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,4 @@
 <?php
 
 $conf['add historical bookings'] = 0;
+$conf['column labels'] = 0;

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,0 +1,3 @@
+<?php
+
+$conf['add historical bookings'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,0 +1,3 @@
+<?php
+
+$meta['add historical bookings'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,3 +1,4 @@
 <?php
 
 $meta['add historical bookings'] = array('onoff');
+$meta['column labels'] = array('onoff');

--- a/helper.php
+++ b/helper.php
@@ -16,7 +16,27 @@ class helper_plugin_booking extends DokuWiki_Plugin
     const E_NOLENGTH = 1;
     const E_OVERLAP = 2;
 
+    // List of columns to display
+    protected $columns = [ 'startend', 'user' ];
 
+    // Labels for each displayed column
+    protected $labels;
+    
+    public function getColumns()
+    {
+        return $this->columns;
+    }
+
+    public function getLabels()
+    {
+        return $this->labels;
+    }
+
+    public function setLabels($labels)
+    {
+        $this->labels = $labels;
+    }
+    
     /**
      * Get the filename where the booking data is stored for this resource
      *
@@ -74,6 +94,101 @@ class helper_plugin_booking extends DokuWiki_Plugin
         ksort($bookings);
         return $bookings;
     }
+
+
+    /**
+     * Wrap a string with a given HTML wrapper
+     *
+     * @param string $text the string to be wrapped
+     * @param string $wrapper the HTML wrapper to apply to the string
+     * @return string The wrapped string
+     */
+    public function htmlWrap($text, $wrapper, $class='')
+    {
+        if ($class !== '') {
+            $output = "<{$wrapper} class=\"{$class}\">{$text}</{$wrapper}>";
+        } else {
+            $output = "<{$wrapper}>{$text}</{$wrapper}>";
+        }
+        return $output;
+    }
+
+    /**
+     * Wrap string of table rows with heading, and table header and footer
+     *
+     * @param string $rows
+     * @param string $heading
+     * @param string $use_header_row
+     * @return string Returns full table html as a string
+     */    
+    public function tableWrap($rows, $heading, $use_header_row=true)
+    {
+        // wrap table row html with heading, header, and footer
+        $prefix = $this->htmlWrap($heading, 'h3');
+        $prefix .= $this->tableHeader($use_header_row);
+        $output = $prefix . $rows . '</table>';
+        return $output;
+    }
+    
+    
+    /**
+     * Construct table header for a booking as a string
+     *
+     * @param string $use_header_row
+     * @return string Returns table header as a string
+     */
+    public function tableHeader($use_header_row=true)
+    {	
+        $theader = '';
+        if ($use_header_row == true) {
+            foreach(array_combine($this->columns, $this->labels) as $column => $label) {
+                $theader .= $this->htmlWrap($label, 'th', $column);
+            }
+            $theader .= $this->htmlWrap('&nbsp;', 'td', 'cancel');
+            $theader = $this->htmlWrap($theader, 'tr');
+        }
+	
+        $theader = '<table class="inline">'. $theader;
+	
+        return $theader;
+    }
+
+    /**
+     * Construct HTML for a table row for a booking as a string
+     *
+     * @param string $booking
+     * @param string $use_cancel_link
+     * @param string $cancel_string
+     * @return string Returns table row HTML as a string
+     */
+    public function tableRow($booking, $use_cancel_link=false,
+                             $cancel_string='cancel')
+    {
+        $trow = '';
+        foreach($this->columns as $column) {
+            switch($column) {
+            case "startend":
+                $tcell = dformat($booking['start']) . ' - ' . dformat($booking['end']);
+                break;
+            case "user":
+                $tcell = userlink($booking['user']);
+                break;
+            }
+            $tcell = $this->htmlWrap($tcell, 'td', $column);
+            $trow = $trow . $tcell;
+        }
+        
+        if ($use_cancel_link == true) {
+            $tcancel = "<a href=\"#{$booking['start']}\" class=\"cancel\">{$cancel_string}</a>";
+        } else {
+            $tcancel = '&nbsp;';
+        }
+        $tcancel = $this->htmlWrap($tcancel, 'td', 'cancel');
+        $trow = $trow . $tcancel;
+        $trow = $this->htmlWrap($trow, 'tr');
+
+        return $trow;
+    }    
 
     /**
      * Parses simple time length strings to seconds

--- a/helper.php
+++ b/helper.php
@@ -21,7 +21,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
 
     // Labels for each displayed column
     protected $labels;
-    
+
     public function getColumns()
     {
         return $this->columns;
@@ -36,7 +36,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
     {
         $this->labels = $labels;
     }
-    
+
     /**
      * Get the filename where the booking data is stored for this resource
      *
@@ -120,7 +120,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
      * @param string $heading
      * @param string $use_header_row
      * @return string Returns full table html as a string
-     */    
+     */
     public function tableWrap($rows, $heading, $use_header_row=true)
     {
         // wrap table row html with heading, header, and footer
@@ -129,8 +129,8 @@ class helper_plugin_booking extends DokuWiki_Plugin
         $output = $prefix . $rows . '</table>';
         return $output;
     }
-    
-    
+
+
     /**
      * Construct table header for a booking as a string
      *
@@ -138,7 +138,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
      * @return string Returns table header as a string
      */
     public function tableHeader($use_header_row=true)
-    {	
+    {
         $theader = '';
         if ($use_header_row == true) {
             foreach(array_combine($this->columns, $this->labels) as $column => $label) {
@@ -147,9 +147,9 @@ class helper_plugin_booking extends DokuWiki_Plugin
             $theader .= $this->htmlWrap('&nbsp;', 'td', 'cancel');
             $theader = $this->htmlWrap($theader, 'tr');
         }
-	
+
         $theader = '<table class="inline">'. $theader;
-	
+
         return $theader;
     }
 
@@ -177,7 +177,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
             $tcell = $this->htmlWrap($tcell, 'td', $column);
             $trow = $trow . $tcell;
         }
-        
+
         if ($use_cancel_link == true) {
             $tcancel = "<a href=\"#{$booking['start']}\" class=\"cancel\">{$cancel_string}</a>";
         } else {
@@ -188,7 +188,7 @@ class helper_plugin_booking extends DokuWiki_Plugin
         $trow = $this->htmlWrap($trow, 'tr');
 
         return $trow;
-    }    
+    }
 
     /**
      * Parses simple time length strings to seconds

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -16,6 +16,9 @@ $lang['book'] = 'Book';
 $lang['cancel'] = 'Cancel';
 $lang['csv'] = 'Download CSV';
 
+$lang['startend'] = 'Start - End';
+$lang['user'] = 'User';
+
 $lang['exception1'] = 'No valid length was given. Booking not created.';
 $lang['exception2'] = 'Overlapping booking already exists. Booking not created.';
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,0 +1,3 @@
+<?php
+
+$lang['add historical bookings'] = 'Enable adding of historical bookings (up to the beginning of the year or two months ago, whichever is earlier)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,4 @@
 <?php
 
 $lang['add historical bookings'] = 'Enable adding of historical bookings (to beginning of year or two months ago, whichever is earlier)';
+$lang['column labels'] = 'Show column labels';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,3 +1,3 @@
 <?php
 
-$lang['add historical bookings'] = 'Enable adding of historical bookings (up to the beginning of the year or two months ago, whichever is earlier)';
+$lang['add historical bookings'] = 'Enable adding of historical bookings (to beginning of year or two months ago, whichever is earlier)';


### PR DESCRIPTION
This pull request creates a configuration to show/hide column labels in the table of bookings. The column labels are specified in `lang/en/lang.php` as `$lang['startend']` and `$lang['user']`. This pull request includes commits from my previous pull request (configuration option for historical bookings) by mistake, but if both pull requests are accepted, then it shouldn't matter.